### PR TITLE
Update install.md

### DIFF
--- a/docs/hybris/install.md
+++ b/docs/hybris/install.md
@@ -61,7 +61,7 @@ The folder structure of this project already contains everything that is needed 
 	```
 - install the addon to your storefront, e.g.:
 	```
-	ant addoninstall -Daddonnames="amplienceaddon" -DaddonStorefront.yacceleratorstorefront="yacceleratorstorefront"
+	ant addoninstall -Daddonnames="amplienceaddon" -DaddonStorefront.yacceleratorstorefront="<YOUR_STOREFRONT_EXTENSION_HERE>"
 	```
 - build your system, e.g.:
 	```


### PR DESCRIPTION
Existing projects mostly have an own storefront extension. So they don't want install the addon to the yacceleratorstorefront but to their own storefront.